### PR TITLE
Fix error when there is no leaderboard entry

### DIFF
--- a/Plugin/src/main/java/dev/lrxh/neptune/game/leaderboard/LeaderboardService.java
+++ b/Plugin/src/main/java/dev/lrxh/neptune/game/leaderboard/LeaderboardService.java
@@ -17,6 +17,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
@@ -97,6 +98,7 @@ public class LeaderboardService {
 
     public List<PlayerEntry> getPlayerEntries(Kit kit, LeaderboardType leaderboardType) {
         List<LeaderboardEntry> leaderboardEntries = leaderboards.get(kit);
+        if (leaderboardEntries == null) return Collections.emptyList();
         for (LeaderboardEntry leaderboardEntry : leaderboardEntries) {
             if (leaderboardEntry.getType().equals(leaderboardType)) {
                 return leaderboardEntry.getPlayerEntries();


### PR DESCRIPTION
```
[07:27:42 ERROR]: Could not pass event PlayerInteractEvent to Neptune v1.9.3
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "leaderboardEntries" is null
        at Neptune.jar/dev.lrxh.neptune.game.leaderboard.LeaderboardService.getPlayerEntries(LeaderboardService.java:100) ~[Neptune.jar:?]
        at Neptune.jar/dev.lrxh.neptune.game.leaderboard.menu.LeaderboardMenu.getButtonItem(LeaderboardMenu.java:94) ~[Neptune.jar:?]
        at Neptune.jar/dev.lrxh.neptune.game.leaderboard.menu.LeaderboardMenu.getButtons(LeaderboardMenu.java:35) ~[Neptune.jar:?]
        at Neptune.jar/dev.lrxh.neptune.utils.menu.Menu.open(Menu.java:67) ~[Neptune.jar:?]
        at Neptune.jar/dev.lrxh.neptune.feature.hotbar.impl.ItemAction$6.execute(ItemAction.java:71) ~[Neptune.jar:?]
        at Neptune.jar/dev.lrxh.neptune.feature.hotbar.listener.ItemListener.onPlayerInteract(ItemListener.java:49) ~[Neptune.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:603) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:559) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:554) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:550) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItem(ServerGamePacketListenerImpl.java:2014) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.network.protocol.game.ServerboundUseItemPacket.handle(ServerboundUseItemPacket.java:48) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.network.protocol.game.ServerboundUseItemPacket.handle(ServerboundUseItemPacket.java:9) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:29) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1448) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1428) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1422) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1379) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1387) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1264) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.4.jar:1.21.4-232-12d8fe0]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```