### PR TITLE
Username-based duel accept/deny

### DIFF
--- a/Plugin/src/main/java/com/jonahseguin/drink/annotation/Command.java
+++ b/Plugin/src/main/java/com/jonahseguin/drink/annotation/Command.java
@@ -18,4 +18,6 @@ public @interface Command {
     String usage() default "";
 
     boolean async() default false;
+
+    boolean hidden() default false;
 }

--- a/Plugin/src/main/java/com/jonahseguin/drink/command/CommandExtractor.java
+++ b/Plugin/src/main/java/com/jonahseguin/drink/command/CommandExtractor.java
@@ -55,7 +55,7 @@ public class CommandExtractor {
             }
             DrinkCommand drinkCommand = new DrinkCommand(
                     commandService, command.name(), Sets.newHashSet(command.aliases()), command.desc(), command.usage(), command.async(),
-                    perm, handler, method
+                    perm, command.hidden(), handler, method
             );
             return Optional.of(drinkCommand);
         }

--- a/Plugin/src/main/java/com/jonahseguin/drink/command/DrinkCommand.java
+++ b/Plugin/src/main/java/com/jonahseguin/drink/command/DrinkCommand.java
@@ -29,8 +29,9 @@ public class DrinkCommand {
     private final int requiredArgCount;
     private final boolean requiresAsync;
     private final String generatedUsage;
+    private final boolean hidden;
 
-    public DrinkCommand(DrinkCommandService commandService, String name, Set<String> aliases, String description, String usage, boolean async, String permission, Object handler, Method method) throws MissingProviderException, CommandStructureException {
+    public DrinkCommand(DrinkCommandService commandService, String name, Set<String> aliases, String description, String usage, boolean async, String permission, boolean hidden, Object handler, Method method) throws MissingProviderException, CommandStructureException {
         this.commandService = commandService;
         this.name = name;
         this.aliases = aliases;
@@ -46,6 +47,7 @@ public class DrinkCommand {
         this.consumingProviders = calculateConsumingProviders();
         this.requiresAsync = async || calculateRequiresAsync();
         this.generatedUsage = generateUsage();
+        this.hidden = hidden;
         this.allAliases = aliases;
         if (name.length() > 0 && !name.equals(DrinkCommandService.DEFAULT_KEY)) {
             allAliases.add(name);

--- a/Plugin/src/main/java/com/jonahseguin/drink/command/DrinkCommandContainer.java
+++ b/Plugin/src/main/java/com/jonahseguin/drink/command/DrinkCommandContainer.java
@@ -51,6 +51,7 @@ public class DrinkCommandContainer extends Command implements PluginIdentifiable
         final String p = prefix.toLowerCase();
         List<String> suggestions = new ArrayList<>();
         for (DrinkCommand c : commands.values()) {
+            if (c.isHidden()) continue;
             for (String alias : c.getAllAliases()) {
                 if (alias.length() > 0) {
                     if (p.length() == 0 || alias.toLowerCase().startsWith(p)) {

--- a/Plugin/src/main/java/dev/lrxh/neptune/game/duel/command/DuelCommand.java
+++ b/Plugin/src/main/java/dev/lrxh/neptune/game/duel/command/DuelCommand.java
@@ -13,11 +13,14 @@ import dev.lrxh.neptune.profile.data.GameData;
 import dev.lrxh.neptune.profile.data.ProfileState;
 import dev.lrxh.neptune.profile.impl.Profile;
 import dev.lrxh.neptune.providers.clickable.Replacement;
+import dev.lrxh.neptune.providers.request.Request;
 import dev.lrxh.neptune.utils.CC;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.util.Optional;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 public class DuelCommand {
 
@@ -58,8 +61,8 @@ public class DuelCommand {
         new KitSelectMenu(target.getUniqueId(), userProfile.getState().equals(ProfileState.IN_PARTY)).open(player);
     }
 
-    @Command(name = "accept", desc = "", usage = "<uuid>")
-    public void accept(@Sender Player player, UUID uuid) {
+    @Command(name = "accept-uuid", desc = "", usage = "<uuid>", hidden = true)
+    public void acceptUUID(@Sender Player player, UUID uuid) {
         Profile profile = API.getProfile(player);
         GameData playerGameData = API.getProfile(player).getGameData();
 
@@ -102,7 +105,49 @@ public class DuelCommand {
         profile.acceptDuel(uuid);
     }
 
-    @Command(name = "specfic", desc = "", usage = "<player> <kit> <rounds>")
+    @Command(name = "accept", desc = "", usage = "<player>")
+    public void accept(@Sender Player player, Player target) {
+        Profile profile = API.getProfile(player);
+        GameData playerGameData = API.getProfile(player).getGameData();
+
+        if (profile.getMatch() != null || profile.getState().equals(ProfileState.IN_SPECTATOR) || profile.hasState(ProfileState.IN_KIT_EDITOR) || profile.hasState(ProfileState.IN_QUEUE)) {
+            player.sendMessage(CC.error("You can't accept duel requests right now!"));
+            return;
+        }
+
+        if (target == null) {
+            player.sendMessage(CC.error("Player isn't online!"));
+            return;
+        }
+
+        Profile targetProfile = API.getProfile(target);
+
+        DuelRequest duelRequest = (DuelRequest) playerGameData.getRequests().get(target.getUniqueId());
+
+        if (duelRequest == null) {
+            player.sendMessage(CC.error("You don't have any duel request from this player!"));
+            return;
+        }
+
+        if (!duelRequest.isParty() && targetProfile.getState().equals(ProfileState.IN_PARTY)) {
+            player.sendMessage(CC.error("Duel request couldn't be accepted!"));
+            return;
+        }
+
+        if (duelRequest.isParty() && !profile.getState().equals(ProfileState.IN_PARTY)) {
+            player.sendMessage(CC.error("Duel request couldn't be accepted!"));
+            return;
+        }
+
+        if (duelRequest.isParty() && !targetProfile.getState().equals(ProfileState.IN_PARTY)) {
+            player.sendMessage(CC.error("Duel request couldn't be accepted!"));
+            return;
+        }
+
+        profile.acceptDuel(duelRequest.getSender());
+    }
+
+    @Command(name = "specific", desc = "", usage = "<player> <kit> <rounds>")
     public void duel(@Sender Player player, Player target, Kit kit, int rounds) {
         if (API.getProfile(player).getMatch() != null) {
             player.sendMessage(CC.error("You can't send duel requests right now!"));
@@ -142,8 +187,8 @@ public class DuelCommand {
         ProfileService.get().getByUUID(target.getUniqueId()).sendDuel(duelRequest);
     }
 
-    @Command(name = "deny", desc = "", usage = "<uuid>")
-    public void deny(@Sender Player player, UUID uuid) {
+    @Command(name = "deny-uuid", desc = "", usage = "<uuid>", hidden = true)
+    public void denyUUID(@Sender Player player, UUID uuid) {
         Profile profile = API.getProfile(player);
         GameData playerGameData = profile.getGameData();
 
@@ -159,5 +204,23 @@ public class DuelCommand {
                 new Replacement("<player>", player.getName()));
 
         playerGameData.removeRequest(uuid);
+    }
+    @Command(name = "deny", desc = "", usage = "<player>")
+    public void deny(@Sender Player player, Player target) {
+        Profile profile = API.getProfile(player);
+        GameData playerGameData = profile.getGameData();
+
+        DuelRequest duelRequest = (DuelRequest) playerGameData.getRequests().get(player.getUniqueId());
+
+        if (duelRequest == null) {
+            player.sendMessage(CC.error("You don't have any duel request from this player!"));
+            return;
+        }
+
+        MessagesLocale.DUEL_DENY_SENDER.send(player.getUniqueId());
+        MessagesLocale.DUEL_DENY_RECEIVER.send(player,
+                new Replacement("<player>", player.getName()));
+
+        playerGameData.removeRequest(player.getUniqueId());
     }
 }

--- a/Plugin/src/main/java/dev/lrxh/neptune/profile/impl/Profile.java
+++ b/Plugin/src/main/java/dev/lrxh/neptune/profile/impl/Profile.java
@@ -210,10 +210,10 @@ public class Profile {
         gameData.addRequest(duelRequest, senderUUID, ignore -> MessagesLocale.DUEL_EXPIRED.send(senderUUID, new Replacement("<player>", player.getName())));
 
         TextComponent accept =
-                new ClickableComponent(MessagesLocale.DUEL_ACCEPT.getString(), "/duel accept " + duelRequest.getSender().toString(), MessagesLocale.DUEL_ACCEPT_HOVER.getString()).build();
+                new ClickableComponent(MessagesLocale.DUEL_ACCEPT.getString(), "/duel accept-uuid " + duelRequest.getSender().toString(), MessagesLocale.DUEL_ACCEPT_HOVER.getString()).build();
 
         TextComponent deny =
-                new ClickableComponent(MessagesLocale.DUEL_DENY.getString(), "/duel deny " + duelRequest.getSender().toString(), MessagesLocale.DUEL_DENY_HOVER.getString()).build();
+                new ClickableComponent(MessagesLocale.DUEL_DENY.getString(), "/duel deny-uuid " + duelRequest.getSender().toString(), MessagesLocale.DUEL_DENY_HOVER.getString()).build();
 
         MessagesLocale.DUEL_REQUEST_RECEIVER.send(playerUUID,
                 new Replacement("<accept>", accept),


### PR DESCRIPTION
Changes the button-based duel commands to separate commands: accept-uuid and deny-uuid.
Adds a `hidden` parameter to Drink for hiding accept-uuid and deny-uuid from tab completion.
Also includes a spelling mistake: `specfic` -> `specific`